### PR TITLE
[docs] Clarify webircgateway usage in example conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Add the plugin javascript file to your kiwiirc `config.json` and configure the s
 }
 ```
 
+If you're running the fileuploader server as a webircgateway plugin, use the webircgateway hostname, e.g.
+
+```json
+		"server": "https://ws.irc.example.com/files",
+```
+
 ## Database configuration
 File uploads are logged into a database. Currently the supported databases are sqlite and mysql.
 

--- a/fileuploader.config.example.toml
+++ b/fileuploader.config.example.toml
@@ -1,8 +1,15 @@
 [Server]
 ListenAddress = "127.0.0.1:8088"
+# Note: ListenAddress is not used when running as a webircgateway plugin.  In
+# those situations, the listen addresses of the webircgateway will be used,
+# including HTTPS if configured.
+
 BasePath = "/files"
 # BasePath = "https://example.com/files" # external URL for use behind reverse proxy
 # CorsOrigins = [ "http://example.com" , "https://example.org" ]
+
+# When running as a webircgateway plugin, this path will be relative to the
+# webircgateway domain, e.g. https://ws.irc.example.com/files
 
 # Requests from these networks will have their X-Forwarded-For headers trusted
 TrustedReverseProxyRanges = [


### PR DESCRIPTION
## In short
* Clarify example configuration for running as a webircgateway plugin
  * Add note on sharing `ListenAddress` including HTTPS if enabled
  * Add example path for `BasePath`, noting it's relative to webircgateway
* Clarify `README.md` documentation on webircgateway plugin path

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Less confusion when setting up fileuploader plugin
Risk | ★☆☆ *1/3* | New examples might clutter the documentation or mislead
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other PRs

*As this is a minor pull request, I've skipped some of the in-depth analysis.*

## Examples
### `fileuploader.config.example.toml`

```diff
  [Server]
  ListenAddress = "127.0.0.1:8088"
+ # Note: ListenAddress is not used when running as a webircgateway plugin.  In
+ # those situations, the listen addresses of the webircgateway will be used,
+ # including HTTPS if configured.
+ 
  BasePath = "/files"
  # BasePath = "https://example.com/files" # external URL for use behind reverse proxy
  # CorsOrigins = [ "http://example.com" , "https://example.org" ]
  
+ # When running as a webircgateway plugin, this path will be relative to the
+ # webircgateway domain, e.g. https://ws.irc.example.com/files
+ 
  # Requests from these networks will have their X-Forwarded-For headers trusted
  TrustedReverseProxyRanges = [
	  "10.0.0.0/8",
```

### `README.md`

*[Preview the file](https://github.com/digitalcircuit/plugin-fileuploader/blob/d18af103af64930da387d4bdfd8e0b8753853f72/README.md#loading-the-plugin-into-kiwiirc ), or see the snippet below:*

> If you're running the fileuploader server as a webircgateway plugin, use the webircgateway hostname, e.g.
>
> ```json
> 		"server": "https://ws.irc.example.com/files",
> ```