### PR TITLE
Logger: no such file or directory

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -95,7 +95,7 @@ func createMultiLogger(loggerConfigs []LoggerConfig) (*zerolog.Logger, error) {
 		url := loggerCfg.Output.URL
 		switch url.Scheme {
 		case "file":
-			file, err := os.OpenFile(url.Path, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0640)
+			file, err := os.OpenFile(url.Path + url.Opaque, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0640)
 			if err != nil {
 				return nil, err
 			}

--- a/server/config.go
+++ b/server/config.go
@@ -95,7 +95,7 @@ func createMultiLogger(loggerConfigs []LoggerConfig) (*zerolog.Logger, error) {
 		url := loggerCfg.Output.URL
 		switch url.Scheme {
 		case "file":
-			file, err := os.OpenFile(url.Opaque, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0640)
+			file, err := os.OpenFile(url.Path, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0640)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
{"level":"error","error":"open : no such file or directory","time":"2023-03-10T00:29:08-08:00","message":"Failed to create MultiLogger"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xee7b54]

goroutine 8 [running]:
github.com/rs/zerolog.(*Logger).should(0x1c?, 0x45?)
/home/baytuch/go/pkg/mod/github.com/rs/zerolog@v1.14.3/log.go:405 +0x14
github.com/rs/zerolog.(*Logger).newEvent(0x0, 0x1, 0x0)
/home/baytuch/go/pkg/mod/github.com/rs/zerolog@v1.14.3/log.go:387 +0x34
github.com/rs/zerolog.(*Logger).Info(...)
/home/baytuch/go/pkg/mod/github.com/rs/zerolog@v1.14.3/log.go:277
github.com/kiwiirc/plugin-fileuploader/server.(*RunContext).runLoop(0xc000158900)
/home/baytuch/plugin-fileuploader/server/server.go:99 +0x358
created by github.com/kiwiirc/plugin-fileuploader/server.(*RunContext).Run
/home/baytuch/plugin-fileuploader/server/server.go:43 +0x97

When I try write log to file in the absolute path:
[[Loggers]]
#Level = "info"
Level = "debug"
Format = "pretty"
Output = "file:/var/log/webgate/fileuploader.log"
#Output = "stderr:"